### PR TITLE
Add entrypoint to build the docs and serve them over http

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+git clone https://github.com/matplotlib/matplotlib
+cd matplotlib/
+pip install -ve .
+cd doc/
+make html
+python -m http.server -d build/html/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 git clone https://github.com/matplotlib/matplotlib
-cd matplotlib/
-pip install -ve .
-cd doc/
-make html
-python -m http.server -d build/html/
+pip install -ve ./matplotlib
+make -C matplotlib/doc html
+python -m http.server -d matplotlib/doc/build/html/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 git clone https://github.com/matplotlib/matplotlib
 pip install -ve ./matplotlib


### PR DESCRIPTION
To be used as:
```bash
$ docker run -it --rm -p 8000:8000 -v $PWD:/tmp/bin/ mrakitin/mpl-docker:latest bash /tmp/bin/entrypoint.sh
```
Cloning of the MPL repo may take a long time, but once it's done, it will install the package in the dev-mode, will build the docs and will start serving them from the `docs/build/html/` directory.

Access on the host machine: http://localhost:8000

**A note to myself:** this `entrypoint.sh` script should be made a part of the Docker image, so can be executed without mounting.

attn @tacaswell 