### PR TITLE
add luatex to fix test_pdf_pages_lualatex failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get -qq update && \
       texlive-latex-extra \
       texlive-fonts-recommended \
       texlive-latex-recommended \
+      texlive-luatex \
       texlive-pictures \
       texlive-xetex \
       graphviz \


### PR DESCRIPTION
the only test that fails when I use this (absolutely wonderful, thank you so much!) dockerfile is [def test_pdf_pages_lualatex()](https://github.com/matplotlib/matplotlib/blob/105d7550205f9e60176f64be014aff7f76d0d939/lib/matplotlib/tests/test_backend_pgf.py#L257) and installing texlive-luatex seems to fix it. According to this stackoverflow (https://tex.stackexchange.com/questions/410949/latex-error-file-luaotfload-sty-not-found), it seems like it's due to changes in ubuntu latex packaging.