### PR TITLE
Update Dockerfile for removing libpng

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,7 @@ RUN apt-get install -y \
       build-essential \
       bzip2 \
       gcc \
-      g++ \
-      libpng12-dev
+      g++
 
 # Create a user, since we don't want to run as root
 ENV USER mpl


### PR DESCRIPTION
matplotlib does not depends on libpng anymore as discussed here, https://github.com/matplotlib/matplotlib/pull/15750

So, I updated Dockerfile for removing libpng.