### PR TITLE
Update and shrink images a bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:xenial
 MAINTAINER MPL developers
 
 # Install apt packages (from https://github.com/matplotlib/matplotlib/blob/master/.circleci/config.yml)
-RUN apt-get -qq update && \
-    apt-get install -y \
+RUN apt -qq update && \
+    apt install -y \
       inkscape \
       ffmpeg \
       dvipng \
@@ -22,7 +22,7 @@ RUN apt-get -qq update && \
       fonts-freefont-otf
 
 # Extra utility packages used below and interactively later
-RUN apt-get install -y \
+RUN apt install -y \
       wget \
       bzip2 \
       git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN cd && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda && \
     rm Miniconda*.sh
 ENV PYTHONUNBUFFERED 1
-RUN conda install python=3.7 pip
+RUN conda install -y python=3.7 pip
 
 # Install MPL docs and testing dependencies
 RUN pip install -vr https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/doc/doc-requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,23 @@ MAINTAINER MPL developers
 # Install apt packages (from https://github.com/matplotlib/matplotlib/blob/master/.circleci/config.yml)
 RUN apt -qq update && \
     apt install -y \
-      inkscape \
-      ffmpeg \
-      dvipng \
-      lmodern \
       cm-super \
+      dvipng \
+      ffmpeg \
+      fonts-crosextra-carlito \
+      fonts-freefont-otf \
+      fonts-humor-sans \
+      graphviz \
+      inkscape\
+      lmodern \
+      optipng\
+      texlive-fonts-recommended \
       texlive-latex-base \
       texlive-latex-extra \
-      texlive-fonts-recommended \
       texlive-latex-recommended \
       texlive-luatex \
       texlive-pictures \
       texlive-xetex \
-      graphviz \
-      fonts-crosextra-carlito \
-      fonts-freefont-otf \
-      fonts-humor-sans \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,9 @@ RUN apt -qq update && \
 ENV PYTHONUNBUFFERED 1
 
 # Install MPL docs and testing dependencies
-RUN pip install -vr https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/doc/doc-requirements.txt
-RUN pip install -vr https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/testing/travis_all.txt
+RUN pip install \
+        -r https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/doc/doc-requirements.txt \
+        -r https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/testing/travis_all.txt
 
 # Fonts
 RUN mkdir -p $HOME/.local/share/fonts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM python:3.7
 MAINTAINER MPL developers
 
 # Install apt packages (from https://github.com/matplotlib/matplotlib/blob/master/.circleci/config.yml)
@@ -22,34 +22,7 @@ RUN apt -qq update && \
       fonts-freefont-otf \
       fonts-humor-sans
 
-# Extra utility packages used below and interactively later
-RUN apt install -y \
-      wget \
-      bzip2 \
-      git \
-      make \
-      build-essential \
-      bzip2 \
-      gcc \
-      g++
-
-# Create a user, since we don't want to run as root
-ENV USER mpl
-RUN useradd -m $USER
-ENV HOME /home/$USER
-WORKDIR $HOME
-USER $USER
-
-# Add the conda binary folder to the path
-ENV PATH $HOME/miniconda/bin:$PATH
-
-# Install miniconda and python
-RUN cd && \
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh --no-verbose && \
-    bash Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda && \
-    rm Miniconda*.sh
 ENV PYTHONUNBUFFERED 1
-RUN conda install -y python=3.7 pip
 
 # Install MPL docs and testing dependencies
 RUN pip install -vr https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/doc/doc-requirements.txt
@@ -60,3 +33,6 @@ RUN mkdir -p $HOME/.local/share/fonts
 RUN wget -nc "https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true" -O "$HOME/.local/share/fonts/Felipa-Regular.ttf" || true
 RUN fc-cache -f -v
 ENV MPLLOCALFREETYPE 1
+
+# Switch back to normal shell for now.
+CMD [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN apt -qq update && \
       texlive-pictures \
       texlive-xetex \
       graphviz \
-      libgeos-dev \
       fonts-crosextra-carlito \
       fonts-freefont-otf \
       fonts-humor-sans

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN pip install --no-cache-dir \
 RUN mkdir -p $HOME/.local/share/fonts
 RUN wget -nc "https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true" -O "$HOME/.local/share/fonts/Felipa-Regular.ttf" || true
 RUN fc-cache -f -v
-ENV MPLLOCALFREETYPE 1
 
 # Switch back to normal shell for now.
 CMD [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apt -qq update && \
       graphviz \
       libgeos-dev \
       fonts-crosextra-carlito \
-      fonts-freefont-otf
+      fonts-freefont-otf \
+      fonts-humor-sans
 
 # Extra utility packages used below and interactively later
 RUN apt install -y \
@@ -57,15 +58,5 @@ RUN pip install -vr https://raw.githubusercontent.com/matplotlib/matplotlib/mast
 # Fonts
 RUN mkdir -p $HOME/.local/share/fonts
 RUN wget -nc "https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true" -O "$HOME/.local/share/fonts/Felipa-Regular.ttf" || true
-RUN if [ ! -f "$HOME/.local/share/fonts/Humor-Sans.ttf" ]; then \
-      wget "https://mirrors.kernel.org/ubuntu/pool/universe/f/fonts-humor-sans/fonts-humor-sans_1.0-1_all.deb" && \
-      mkdir tmp && \
-      dpkg -x fonts-humor-sans_1.0-1_all.deb tmp && \
-      cp tmp/usr/share/fonts/truetype/humor-sans/Humor-Sans.ttf $HOME/.local/share/fonts && \
-      rm -rf tmp && \
-      rm -f fonts-humor-sans_1.0-1_all.deb; \
-    else \
-      echo "Not downloading Humor-Sans; file already exists."; \
-    fi
 RUN fc-cache -f -v
 ENV MPLLOCALFREETYPE 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ ENV PYTHONUNBUFFERED 1
 # Install MPL docs and testing dependencies
 RUN pip install --no-cache-dir \
         -r https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/doc/doc-requirements.txt \
-        -r https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/testing/travis_all.txt
+        -r https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/testing/travis_all.txt \
+        cycler kiwisolver numpy pillow pyparsing python-dateutil
 
 # Fonts
 RUN mkdir -p $HOME/.local/share/fonts

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,13 @@ RUN apt -qq update && \
       graphviz \
       fonts-crosextra-carlito \
       fonts-freefont-otf \
-      fonts-humor-sans
+      fonts-humor-sans \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED 1
 
 # Install MPL docs and testing dependencies
-RUN pip install \
+RUN pip install --no-cache-dir \
         -r https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/doc/doc-requirements.txt \
         -r https://raw.githubusercontent.com/matplotlib/matplotlib/master/requirements/testing/travis_all.txt
 


### PR DESCRIPTION
This does a variety of things (see commits) to update and shrink the images. This lines up some things with https://github.com/matplotlib/matplotlib/pull/16848.

I got rid of `conda` because everything is `pip`-installed anyway, so it's not really helping us. Switching from xenial to bionic would have saved 150M more, but instead I went with the official python image as base, due to the reason listed in its docs of better layer sharing. The pre-installed packages also cut out on extra install steps for us.

Using the `fonts-humor-sans` package adds 12 M for some reason, but dropping `libgeos-dev` saves 3M. Bigger savings come from dropping caches for 84M and switching base images for 628M. Overall, the image is 75% of its original size. Most of the remaining size is probably from LaTeX, and I don't think Debian has any finer-granularity packages for that (maybe Fedora would help there, but I don't want to change the container that much arbitrarily.)