### PR TITLE
ENH: add build arg to control Python base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=python:3.8
+ARG BUILDER_IMAGE=python:3.8-slim
 FROM ${BUILDER_IMAGE} as builder
 MAINTAINER MPL developers
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE=3.8
-FROM python:$BASE
+ARG BUILDER_IMAGE=python:3.8
+FROM ${BUILDER_IMAGE} as builder
 MAINTAINER MPL developers
 
 # Install apt packages (from https://github.com/matplotlib/matplotlib/blob/master/.circleci/config.yml)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.7
+ARG BASE=3.8
+FROM python:$BASE
 MAINTAINER MPL developers
 
 # Install apt packages (from https://github.com/matplotlib/matplotlib/blob/master/.circleci/config.yml)


### PR DESCRIPTION
This will let us control with version of the Python image we build on top of.