### PR TITLE
ENH: Add Makefile for local development testing of build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILDER_IMAGE=python:3.8
-FROM ${BUILDER_IMAGE} as builder
+ARG BASE_IMAGE=python:3.8
+FROM ${BASE_IMAGE} as base
 
 # Install apt-get packages (from https://github.com/matplotlib/matplotlib/blob/master/.circleci/config.yml)
 # hadolint ignore=DL3008

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,7 @@ image:
 	--tag matplotlib/mpl-docker:debug-latest
 
 run:
-	docker run --rm -it matplotlib/mpl-docker:debug-latest
+	docker run --rm -it \
+	-v $(shell pwd):/mpl_source \
+	-w /mpl_source \
+	matplotlib/mpl-docker:debug-latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default: image
+
+all: image
+
+image:
+	docker build . \
+	-f Dockerfile \
+	--tag matplotlib/mpl-docker:debug-latest
+
+run:
+	docker run --rm -it matplotlib/mpl-docker:debug-latest

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: image
 image:
 	docker build . \
 	-f Dockerfile \
+	--build-arg BASE_IMAGE=python:3.8 \
 	--tag matplotlib/mpl-docker:debug-latest
 
 run:


### PR DESCRIPTION
Resolves #7 

Add a very simple `Makefile` for local development testing to build the image. This allows for using

```
make
```

to build the image and

```
make run
```

to drop into an interactive session in the image.

This should **wait** for PR #6 to get merged so that this can be rebased and add in build args.