### PR TITLE
ci: Add testing and publishing of Docker image to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  docker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Docker image
+      uses: docker/build-push-action@v1
+      with:
+        repository: matplotlib/mpl-docker
+        dockerfile: Dockerfile
+        tags: test
+        tag_with_sha: true
+        tag_with_ref: true
+        push: false
+    - name: List built images
+      run: docker images

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,6 +6,9 @@ on:
     - master
     tags:
     - v*
+  # Run weekly (Sunday) at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * 0'
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,35 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and Publish to Registry
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: matplotlib/mpl-docker
+        dockerfile: Dockerfile
+        tags: latest
+    - name: Build and Publish to Registry with Release Tag
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: matplotlib/mpl-docker
+        dockerfile: Dockerfile
+        tags: latest,latest-stable
+        tag_with_ref: true

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -9,6 +9,7 @@ on:
   # Run weekly (Sunday) at 0:01 UTC
   schedule:
   - cron:  '1 0 * * 0'
+  workflow_dispatch:
 
 jobs:
   build-and-publish:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=python:3.8-slim
+ARG BUILDER_IMAGE=python:3.8
 FROM ${BUILDER_IMAGE} as builder
 MAINTAINER MPL developers
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## MPL Docker image for building docs
 
+[![GitHub Actions Status: CI](https://github.com/matplotlib/mpl-docker/workflows/CI/svg?branch=master)](https://github.com/matplotlib/mpl-docker/actions?query=workflow%3ACI+branch%3Amaster)
+[![Docker Pulls](https://img.shields.io/docker/pulls/matplotlib/mpl-docker)](https://hub.docker.com/r/matplotlib/mpl-docker)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/matplotlib/mpl-docker/latest)](https://hub.docker.com/r/matplotlib/mpl-docker/tags?name=latest)
+
 ### Usage:
 ```
 docker pull matplotlib/mpl-docker:latest

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 ### Usage:
 ```
-docker pull mrakitin/mpl-docker:latest
-docker run --rm -it mrakitin/mpl-docker:latest bash
+docker pull matplotlib/mpl-docker:latest
+docker run --rm -it matplotlib/mpl-docker:latest bash
 ```


### PR DESCRIPTION
Resolves #9 

Use Docker's [`build-push-action`](https://github.com/docker/build-push-action) GitHub Action to test the image build using the on `push` and `pull_request` events and also on a nightly CRON job that runs at 0:01 UTC. Additionally, add CI to build the Docker image and then publish it to Docker Hub under the tag 'latest'. If this is due to a tag being pushed, then also tag the image with the release tag and tag with 'latest-stable'. **edit:** Also now run weekly deployment of `latest` to Docker Hub as a cron job given the suggestions of @thomasjpfan. It can also be run _on demand_ by using the new [GitHub Actions `workflow_dispatch` system](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/).

This requires the addition of a Docker Hub username and password as GitHub secrets with the following names `DOCKER_USERNAME` and `DOCKER_PASSWORD` to work, which I can't do.

The CI can be seen running on my fork here: https://github.com/matthewfeickert/mpl-docker/actions [![GitHub Actions Status: CI](https://github.com/matthewfeickert/mpl-docker/workflows/CI/badge.svg?branch=ci/add-publish-CI)](https://github.com/matthewfeickert/mpl-docker/actions)

For an example of what the results of these CI patterns would give you in terms of tags c.f. [the `pyhf` Docker Hub tags](https://hub.docker.com/r/pyhf/pyhf/tags).