### PR TITLE
MNT: Revert path change from 'apt' to 'apt-get'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -qq update && \
       texlive-luatex \
       texlive-pictures \
       texlive-xetex \
-    && rm -rf /var/lib/apt-get/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
`apt-get` uses the same directory as `apt`, so to try to clean an `apt-get` path is wrong.