### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"      # Location of your workflow files
+    schedule:
+      interval: "weekly"  # Options: daily, weekly, monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Build Docker image
       uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build Docker image
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1
       with:
         repository: matplotlib/mpl-docker
         dockerfile: Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Build Docker image
-      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1
+      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1.1.2
       with:
         repository: matplotlib/mpl-docker
         dockerfile: Dockerfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on: push
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Lint Dockerfile
         uses: brpaz/hadolint-action@eb9b96be611b84830aa1babacfb7070ecd2a8b1b # v1.1.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Lint Dockerfile
-        uses: brpaz/hadolint-action@v1.1.0
+        uses: brpaz/hadolint-action@eb9b96be611b84830aa1babacfb7070ecd2a8b1b # v1.1.0
         with:
           dockerfile: "Dockerfile"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,4 +1,6 @@
 name: Publish Docker Images
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Build and Publish to Registry
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -24,7 +24,7 @@ jobs:
         persist-credentials: false
     - name: Build and Publish to Registry
       if: "!(startsWith(github.ref, 'refs/tags/'))"
-      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1
+      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1.1.2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -33,7 +33,7 @@ jobs:
         tags: latest
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1
+      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1.1.2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build and Publish to Registry
       if: "!(startsWith(github.ref, 'refs/tags/'))"
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -29,7 +29,7 @@ jobs:
         tags: latest
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v1
+      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions
- adding a depandabot file for GHA
